### PR TITLE
Changed enabled and disabled methods

### DIFF
--- a/ca.ucalgary.seng300.a1/src/ca/ucalgary/seng300/a1/ButtonListenerDevice.java
+++ b/ca.ucalgary.seng300.a1/src/ca/ucalgary/seng300/a1/ButtonListenerDevice.java
@@ -1,0 +1,26 @@
+package ca.ucalgary.seng300.a1;
+
+import org.lsmr.vending.*;
+import org.lsmr.vending.hardware.*;
+
+public class ButtonListenerDevice implements SelectionButtonListener {
+
+	@Override
+	public void enabled(AbstractHardware<? extends AbstractHardwareListener> hardware) {
+		// do nothing for now
+		
+	}
+
+	@Override
+	public void disabled(AbstractHardware<? extends AbstractHardwareListener> hardware) {
+		// do nothing for now
+		
+	}
+
+	@Override
+	public void pressed(SelectionButton button) {
+		// TODO Auto-generated method stub
+		
+	}
+
+}

--- a/ca.ucalgary.seng300.a1/src/ca/ucalgary/seng300/a1/CoinSlotListenerDevice.java
+++ b/ca.ucalgary.seng300.a1/src/ca/ucalgary/seng300/a1/CoinSlotListenerDevice.java
@@ -25,9 +25,7 @@ public class CoinSlotListenerDevice implements CoinSlotListener {
      */
 	@Override
 	public void enabled(AbstractHardware<? extends AbstractHardwareListener> hardware) {
-		hardware.enable();
-		hardware.notify();
-		
+		// Do nothing for now
 	}
 
 	/**
@@ -38,9 +36,7 @@ public class CoinSlotListenerDevice implements CoinSlotListener {
      */
 	@Override
 	public void disabled(AbstractHardware<? extends AbstractHardwareListener> hardware) {
-		hardware.disable(); // won't this cause a stack overflow? hardware.disable() calls notifyDisabled() which calls this method
-		hardware.notify();
-		
+		// Do nothing for now
 	}
 
 	@Override

--- a/ca.ucalgary.seng300.a1/src/ca/ucalgary/seng300/a1/CoinSlotListenerDevice.java
+++ b/ca.ucalgary.seng300.a1/src/ca/ucalgary/seng300/a1/CoinSlotListenerDevice.java
@@ -9,11 +9,9 @@ import org.lsmr.vending.hardware.CoinSlotListener;
 public class CoinSlotListenerDevice implements CoinSlotListener {
 
 	private int value = 0;
-	private boolean disabled = false;
 	
 	public CoinSlotListenerDevice(CoinSlot slot) {
 		slot.register(this);
-		disabled = slot.isDisabled();
 		value = 0;	
 	}
 	
@@ -39,22 +37,41 @@ public class CoinSlotListenerDevice implements CoinSlotListener {
 		// Do nothing for now
 	}
 
+	/**
+	 * Updates value to track the amount of money inserted so far
+	 */
 	@Override
 	public void validCoinInserted(CoinSlot slot, Coin coin) {
-		if (!disabled) {
-			value = value + coin.getValue();
+		if (!slot.isDisabled()) {
+			value += coin.getValue();
 		}
 		
 	}
 
+	/**
+	 * 
+	 */
 	@Override
 	public void coinRejected(CoinSlot slot, Coin coin) {
-		// coins get returned 
+		// TODO coins get returned, or do nothing for now? Since "Mr. Client" isn't worried about dispensing change yet
 		
 	}
 
-	public int getValue(){
+	public int getValue() {
 		return value;
+	}
+	
+	/**
+	 * A setter method for value. Should be called when pop is dispensed to model the payment.
+	 * 
+	 */
+	public void payForItem(int amount) {
+		if (amount >= 0 && amount <= value) {
+			value -= amount;
+		}
+		else {
+			// TODO could create a custom exception or just have it do nothing. Thoughts?
+		}
 	}
 	
 }


### PR DESCRIPTION
The previous methods cause a StackOverflow Exception. Since these
methods are called in hardware methods that already call disable() or
enable(), the listener does not have to perform these functions or do
any notifying. I'm guessing these methods will be important for error
messages and features that are part of the next assignments but for now
I don't think they're necessary for handling coin insertion and button
presses.